### PR TITLE
Remove if statements associated with package loading

### DIFF
--- a/R/metacoder.R
+++ b/R/metacoder.R
@@ -34,20 +34,6 @@ taxonomy_annotate_to_metacoder <- function(taxonomy_annotate_tibble = NULL,
                                            groups = NULL,
                                            groups_prefix = "x",
                                            ...){
-  # guard against missing packages
-  if (!requireNamespace("dplyr", quietly = TRUE)) {
-    stop(
-      "Package \"dplyr\" must be installed to use this function.",
-      call. = FALSE
-    )
-  }
-
-  if (!requireNamespace("metacoder", quietly = TRUE)) {
-    stop(
-      "Package \"metacoder\" must be installed to use this function.",
-      call. = FALSE
-    )
-  }
 
   # either take in tibble from read_taxonomy_annotate or read in sourmash taxonomy annotate output file(s) directly
   if(missing(taxonomy_annotate_tibble) & missing(file)){

--- a/R/read_sourmash_outputs.R
+++ b/R/read_sourmash_outputs.R
@@ -10,33 +10,10 @@
 #' @examples
 #' read_compare_csv("")
 read_compare_csv <- function(file, sample_to_rownames = F, ...){
-  # guard the use of required packages
-  if (!requireNamespace("readr", quietly = TRUE)) {
-    stop(
-      "Package \"readr\" must be installed to use this function.",
-      call. = FALSE
-    )
-  }
-
-  if (!requireNamespace("dplyr", quietly = TRUE)) {
-    stop(
-      "Package \"dplyr\" must be installed to use this function.",
-      call. = FALSE
-    )
-  }
-
   if(sample_to_rownames == F){
-  compare_df <- readr::read_csv(file, ...) %>%
-    dplyr::mutate(sample = colnames(.), .before = everything())
+    compare_df <- readr::read_csv(file, ...) %>%
+      dplyr::mutate(sample = colnames(.), .before = everything())
   } else if(sample_to_rownames == T){
-
-    if (!requireNamespace("tibble", quietly = TRUE)) {
-      stop(
-        "Package \"tibble\" must be installed to make sample names into row names. Please either install \"tibble\" or set sample_to_rownames to FALSE.",
-        call. = FALSE
-      )
-    }
-
     compare_df <- readr::read_csv(file, ...) %>%
       dplyr::mutate(sample = colnames(.), .before = everything()) %>%
       tibble::column_to_rownames("sample")
@@ -56,29 +33,7 @@ read_compare_csv <- function(file, sample_to_rownames = F, ...){
 #' @examples
 #' read_gather()
 read_gather <- function(file, intersect_bp_threshold, ...){
-  if (!requireNamespace("readr", quietly = TRUE)) {
-    stop(
-      "Package \"readr\" must be installed to use this function.",
-      call. = FALSE
-    )
-  }
-
-  if (!requireNamespace("dplyr", quietly = TRUE)) {
-    stop(
-      "Package \"dplyr\" must be installed to use this function.",
-      call. = FALSE
-    )
-  }
-
   if(length(file) > 1){
-
-    if (!requireNamespace("purrr", quietly = TRUE)) {
-      stop(
-        "Package \"purrr\" must be installed to read multiple files at a time. Please either install \"purrr\" or read one file at a time.",
-        call. = FALSE
-      )
-    }
-
     # allow the function to read multiple files at once
     taxonomy_annotate_df <- file %>%
       purrr::map_dfr(readr::read_csv, col_types = "ddddddddcccddddcccddcddlddddl", ...) %>%
@@ -106,29 +61,7 @@ read_gather <- function(file, intersect_bp_threshold, ...){
 #' @examples
 #' read_taxonomy_annotate()
 read_taxonomy_annotate <- function(file, intersect_bp_threshold = 50000, separate_lineage = T, ...){
-  if (!requireNamespace("readr", quietly = TRUE)) {
-    stop(
-      "Package \"readr\" must be installed to use this function.",
-      call. = FALSE
-    )
-  }
-
-  if (!requireNamespace("dplyr", quietly = TRUE)) {
-    stop(
-      "Package \"dplyr\" must be installed to use this function.",
-      call. = FALSE
-    )
-  }
-
   if(length(file) > 1){
-
-    if (!requireNamespace("purrr", quietly = TRUE)) {
-      stop(
-        "Package \"purrr\" must be installed to read multiple files at a time. Please either install \"purrr\" or read one file at a time.",
-        call. = FALSE
-      )
-    }
-
     # allow the function to read multiple files at once
     taxonomy_annotate_df <- file %>%
       purrr::map_dfr(readr::read_csv, col_types = "ddddddddcccddddcccddcddlddddlc", ...) %>%
@@ -142,17 +75,8 @@ read_taxonomy_annotate <- function(file, intersect_bp_threshold = 50000, separat
       dplyr::mutate(genome_accession = gsub(" .*", "", name) , .after = "name")
   }
   if(separate_lineage == T){
-
-    if (!requireNamespace("tidyr", quietly = TRUE)) {
-      stop(
-        "Package \"tidyr\" must be installed to separate taxonomic lineages. Please either install \"tibble\" or set separate_lineage to FALSE.",
-        call. = FALSE
-      )
-    }
-
     taxonomy_annotate_df <- taxonomy_annotate_df %>%
       tidyr::separate(lineage, into = c("domain", "phylum", "class", "order", "family", "genus", "species", "strain"), sep = ";", remove = F, fill = "right")
   }
   return(taxonomy_annotate_df)
 }
-


### PR DESCRIPTION
I was being a dummy. @elizabethmcd pointed out in #8 that there had to be a better way to check for loaded packages...she was right. I got confused in the docs here https://r-pkgs.org/dependencies.html#guarding-the-use-of-a-suggested-package and essentially wrote if statements for any package I was using. However, these if statements are only for suggested packages...right now, I don't have anything as a suggest, everything is a dependencies and as such is imported. if you go to load the package and you don't have one of these libraries installed, it will prompt you with something like:

```
The packages `dplyr`, `ggplot2`, `readr`, and `tidyr` are required.
Would you like to install them?
```

This is based on the DESCRIPTION file.

In the long run, I could switch metacoder (and eventually, phyloseq) and other packages that are pain to install from dependencies to suggests, and I can guard there installations with code like this. but for now I'm comfortable with all of these just being dependencies that are imported. 

FYI I re-ran all of the tests locally and they passed.